### PR TITLE
Makes variable contiguous again

### DIFF
--- a/GreedyInfoMax/vision/models/Resnet_Encoder.py
+++ b/GreedyInfoMax/vision/models/Resnet_Encoder.py
@@ -167,7 +167,7 @@ class ResNet_Encoder(nn.Module):
 
         out = F.adaptive_avg_pool2d(z, 1)
         out = out.reshape(-1, n_patches_x, n_patches_y, out.shape[1])
-        out = out.permute(0, 3, 1, 2)
+        out = out.permute(0, 3, 1, 2).contiguous()
 
         accuracy = torch.zeros(1)
         if self.calc_loss and self.opt.loss == 0:


### PR DESCRIPTION
Fixes the error:
```
CUDNN_STATUS_NOT_SUPPORTED. This error may appear if you passed in a non-contiguous input.
```

The `permute()` operation seems to make the variable `out` non-contiguous (see https://stackoverflow.com/questions/48915810/pytorch-contiguous for discussion).

The issue is solved by making it contiguous again.
