### PR TITLE
Random drawing of audio samples is now random across epochs

### DIFF
--- a/GreedyInfoMax/audio/data/librispeech.py
+++ b/GreedyInfoMax/audio/data/librispeech.py
@@ -5,7 +5,7 @@ import torchaudio
 from collections import defaultdict
 import torch
 import numpy as np
-
+import random
 
 def default_loader(path):
     return torchaudio.load(path, normalization=False)
@@ -60,7 +60,7 @@ class LibriDataset(Dataset):
         ## discard last part that is not a full 10ms
         max_length = audio.size(1) // 160 * 160
 
-        start_idx = np.random.choice(
+        start_idx = random.choice(
             np.arange(160, max_length - self.audio_length - 0, 160)
         )
 

--- a/GreedyInfoMax/audio/main_audio.py
+++ b/GreedyInfoMax/audio/main_audio.py
@@ -1,6 +1,7 @@
 import torch
 import time
 import numpy as np
+import random
 
 #### own modules
 from GreedyInfoMax.utils import logger
@@ -85,6 +86,7 @@ if __name__ == "__main__":
     torch.manual_seed(opt.seed)
     torch.cuda.manual_seed(opt.seed)
     np.random.seed(opt.seed)
+    random.seed(opt.seed)
 
     # load model
     model, optimizer = load_audio_model.load_model_and_optimizer(opt)


### PR DESCRIPTION
While it won't make a huge deal since batches are shuffled; np.random draws the same samples to create batches every epoch due to below mentioned issue. I believe you would want different random examples from the audio, not the same audio samples when present in the batch. 

To verify the issue, I wrote the audio files (turned off shuffling) with the np.random method and uploaded them [here](https://drive.google.com/open?id=18altMuEA7it-tSKpw9OAvvq_GkZOraaG), first index is epoch, then comes the filename (contents of 0-60-121082-0044.mp3 == 1-60-121082-0044.mp3, which should ideally not be).

Reference: https://github.com/pytorch/pytorch/issues/5059