### PR TITLE
patch main_vision.py/main_audio.py for PyTorch v1.5+ compatibility

### DIFF
--- a/GreedyInfoMax/audio/main_audio.py
+++ b/GreedyInfoMax/audio/main_audio.py
@@ -52,13 +52,15 @@ def train(opt, model):
             loss = model(model_input, filename, start_idx, n=opt.train_layer)
             loss = torch.mean(loss, 0)  # average over the losses from different GPUs
 
-            for idx, cur_losses in enumerate(loss):
-                model.zero_grad()
+            model.zero_grad()
 
+            for idx, cur_losses in enumerate(loss):
                 if idx == len(loss) - 1:
                     cur_losses.backward()
                 else:
                     cur_losses.backward(retain_graph=True)
+		    
+            for idx, cur_losses in enumerate(loss):
                 optimizer[idx].step()
 
                 print_loss = cur_losses.item()

--- a/GreedyInfoMax/utils/utils.py
+++ b/GreedyInfoMax/utils/utils.py
@@ -25,6 +25,8 @@ def accuracy(output, target, topk=(1,)):
         pred = pred.t()
         correct = pred.eq(target.view(1, -1).expand_as(pred))
 
+        correct = correct.contiguous()    #required for pytorch V1.7 view()
+
         res = []
         for k in topk:
             correct_k = correct[:k].view(-1).float().sum(0, keepdim=True)

--- a/GreedyInfoMax/vision/main_vision.py
+++ b/GreedyInfoMax/vision/main_vision.py
@@ -77,16 +77,21 @@ def train(opt, model):
                 loss = loss[cur_train_module].unsqueeze(0)
 
             # loop through the losses of the modules and do gradient descent
+            model.zero_grad()
+
             for idx, cur_losses in enumerate(loss):
                 if len(loss) == 1 and opt.model_splits != 1:
                     idx = cur_train_module
-
-                model.zero_grad()
-
+                    
                 if idx == len(loss) - 1:
                     cur_losses.backward()
                 else:
                     cur_losses.backward(retain_graph=True)
+                    
+            for idx, cur_losses in enumerate(loss):
+                if len(loss) == 1 and opt.model_splits != 1:
+                    idx = cur_train_module
+                    
                 optimizer[idx].step()
 
                 print_loss = cur_losses.item()

--- a/GreedyInfoMax/vision/models/ClassificationModel.py
+++ b/GreedyInfoMax/vision/models/ClassificationModel.py
@@ -6,7 +6,7 @@ class ClassificationModel(torch.nn.Module):
     def __init__(self, in_channels=256, num_classes=200, hidden_nodes=0):
         super().__init__()
         self.in_channels = in_channels
-        self.avg_pool = nn.AvgPool2d((7, 7), stride=0, padding=0)
+        self.avg_pool = nn.AvgPool2d((7, 7), padding=0)
         self.model = nn.Sequential()
 
         if hidden_nodes > 0:


### PR DESCRIPTION
This patch updates main_vision.py/main_audio.py for PyTorch v1.5+ compatibility. The particular implementation chosen requires review.

Patch summary:

This patch prevents main_vision.py/main_audio.py from throwing the following error;

"RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation"

The patch involves splitting the model.zero_grad(), cur_losses.backward(), and optimizer[idx].step() operations, such that each operation is executed for each model/layer before the next operation is performed.

It was developed based on a workaround provided here: https://discuss.pytorch.org/t/solved-pytorch1-5-runtimeerror-one-of-the-variables-needed-for-gradient-computation-has-been-modified-by-an-inplace-operation/90256/3

It has been tested on PyTorch v1.4->v1.7 with ~1 epoch of training on both the Vision and Audio models. It has also been tested on PyTorch v1.7 with the vision/audio training parameters set to train_module/train_layer=0/0 and 1/1 (not just 3/6), and likewise with model_splits=1/1 (not just 3/6). There may be significant limitations introduced by the patch not identified by these tests.