### PR TITLE
Faster training by accumulating module-wise losses and using single optimizer

### DIFF
--- a/GreedyInfoMax/audio/models/load_audio_model.py
+++ b/GreedyInfoMax/audio/models/load_audio_model.py
@@ -10,14 +10,14 @@ def load_model_and_optimizer(
     opt, reload_model=False, calc_accuracy=False, num_GPU=None
 ):
 
-    # original dimensions given in CPC paper (Oord et al.)
+    # Original dimensions given in CPC paper (Oord et al.).
     kernel_sizes = [10, 8, 4, 4, 4]
     strides = [5, 4, 2, 2, 2]
     padding = [2, 2, 2, 2, 1]
     enc_hidden = 512
     reg_hidden = 256
 
-    ## initialize model
+    # Initialize model.
     model = full_model.FullModel(
         opt,
         kernel_sizes=kernel_sizes,
@@ -28,24 +28,13 @@ def load_model_and_optimizer(
         calc_accuracy=calc_accuracy,
     )
 
-    # run on only one GPU for supervised losses
+    # Run on only one GPU for supervised losses.
     if opt.loss == 2 or opt.loss == 1:
         num_GPU = 1
 
     model, num_GPU = model_utils.distribute_over_GPUs(opt, model, num_GPU=num_GPU)
 
-    """ initialize optimizers
-    We need to have a separate optimizer for every individually trained part of the network
-    as calling optimizer.step() would otherwise cause all parts of the network to be updated
-    even when their respective gradients are zero (due to momentum)
-    """
-    optimizer = []
-    for idx, layer in enumerate(model.module.fullmodel):
-        if isinstance(opt.learning_rate, list):
-            cur_lr = opt.learning_rate[idx]
-        else:
-            cur_lr = opt.learning_rate
-        optimizer.append(torch.optim.Adam(layer.parameters(), lr=cur_lr))
+    optimizer = torch.optim.Adam(model.parameters(), lr=opt.learning_rate)
 
     model, optimizer = model_utils.reload_weights(opt, model, optimizer, reload_model)
 

--- a/GreedyInfoMax/utils/logger.py
+++ b/GreedyInfoMax/utils/logger.py
@@ -20,14 +20,17 @@ class Logger:
             self.loss_last_training = np.load(
                 os.path.join(opt.model_path, "train_loss.npy")
             ).tolist()
-            self.train_loss[:len(self.loss_last_training)] = copy.deepcopy(self.loss_last_training)
-
+            self.train_loss[: len(self.loss_last_training)] = copy.deepcopy(
+                self.loss_last_training
+            )
 
             if opt.validate:
                 self.val_loss_last_training = np.load(
                     os.path.join(opt.model_path, "val_loss.npy")
                 ).tolist()
-                self.val_loss[:len(self.val_loss_last_training)] = copy.deepcopy(self.val_loss_last_training)
+                self.val_loss[: len(self.val_loss_last_training)] = copy.deepcopy(
+                    self.val_loss_last_training
+                )
             else:
                 self.val_loss = None
         else:
@@ -50,7 +53,7 @@ class Logger:
         final_test=False,
         final_loss=None,
         acc5=None,
-        classification_model=None
+        classification_model=None,
     ):
 
         print("Saving model and log-file to " + self.opt.log_path)
@@ -60,7 +63,9 @@ class Logger:
             for idx, layer in enumerate(model.module.encoder):
                 torch.save(
                     layer.state_dict(),
-                    os.path.join(self.opt.log_path, "model_{}_{}.ckpt".format(idx, epoch)),
+                    os.path.join(
+                        self.opt.log_path, "model_{}_{}.ckpt".format(idx, epoch)
+                    ),
                 )
         else:
             torch.save(
@@ -76,7 +81,9 @@ class Logger:
                         os.remove(
                             os.path.join(
                                 self.opt.log_path,
-                                "model_{}_{}.ckpt".format(idx, epoch - self.num_models_to_keep),
+                                "model_{}_{}.ckpt".format(
+                                    idx, epoch - self.num_models_to_keep
+                                ),
                             )
                         )
                 else:
@@ -89,12 +96,13 @@ class Logger:
             except:
                 print("not enough models there yet, nothing to delete")
 
-
         if classification_model is not None:
             # Save the predict model checkpoint
             torch.save(
                 classification_model.state_dict(),
-                os.path.join(self.opt.log_path, "classification_model_{}.ckpt".format(epoch)),
+                os.path.join(
+                    self.opt.log_path, "classification_model_{}.ckpt".format(epoch)
+                ),
             )
 
             ### remove old model files to keep dir uncluttered
@@ -102,32 +110,29 @@ class Logger:
                 os.remove(
                     os.path.join(
                         self.opt.log_path,
-                        "classification_model_{}.ckpt".format(epoch - self.num_models_to_keep),
+                        "classification_model_{}.ckpt".format(
+                            epoch - self.num_models_to_keep
+                        ),
                     )
                 )
             except:
                 print("not enough models there yet, nothing to delete")
 
         if optimizer is not None:
-            for idx, optims in enumerate(optimizer):
-                torch.save(
-                    optims.state_dict(),
-                    os.path.join(
-                        self.opt.log_path, "optim_{}_{}.ckpt".format(idx, epoch)
-                    ),
-                )
+            torch.save(
+                optimizer.state_dict(),
+                os.path.join(self.opt.log_path, "optim_{}.ckpt".format(epoch)),
+            )
 
-                try:
-                    os.remove(
-                        os.path.join(
-                            self.opt.log_path,
-                            "optim_{}_{}.ckpt".format(
-                                idx, epoch - self.num_models_to_keep
-                            ),
-                        )
+            try:
+                os.remove(
+                    os.path.join(
+                        self.opt.log_path,
+                        "optim_{}.ckpt".format(epoch - self.num_models_to_keep),
                     )
-                except:
-                    print("not enough models there yet, nothing to delete")
+                )
+            except:
+                print("not enough models there yet, nothing to delete")
 
         # Save hyper-parameters
         with open(os.path.join(self.opt.log_path, "log.txt"), "w+") as cur_file:
@@ -160,13 +165,15 @@ class Logger:
             np.save(os.path.join(self.opt.log_path, "final_accuracy"), accuracy)
             np.save(os.path.join(self.opt.log_path, "final_loss"), final_loss)
 
-
     def draw_loss_curve(self):
         for idx, loss in enumerate(self.train_loss):
             lst_iter = np.arange(len(loss))
             plt.plot(lst_iter, np.array(loss), "-b", label="train loss")
 
-            if self.loss_last_training is not None and len(self.loss_last_training) > idx:
+            if (
+                self.loss_last_training is not None
+                and len(self.loss_last_training) > idx
+            ):
                 lst_iter = np.arange(len(self.loss_last_training[idx]))
                 plt.plot(lst_iter, self.loss_last_training[idx], "-g")
 

--- a/GreedyInfoMax/utils/model_utils.py
+++ b/GreedyInfoMax/utils/model_utils.py
@@ -101,18 +101,15 @@ def reload_weights(opt, model, optimizer, reload_model):
                     )
                 )
 
-        for i, optim in enumerate(optimizer):
-            if opt.model_splits > 3 and i > 2:
-                break
-            optim.load_state_dict(
-                torch.load(
-                    os.path.join(
-                        opt.model_path,
-                        "optim_{}_{}.ckpt".format(str(i), opt.start_epoch),
-                    ),
-                    map_location=opt.device.type,
-                )
+        optimizer.load_state_dict(
+            torch.load(
+                os.path.join(
+                    opt.model_path,
+                    "optim_{}.ckpt".format(opt.start_epoch),
+                ),
+                map_location=opt.device.type,
             )
+        )
     else:
         print("Randomly initialized model")
 

--- a/GreedyInfoMax/vision/main_vision.py
+++ b/GreedyInfoMax/vision/main_vision.py
@@ -47,8 +47,8 @@ def train(opt, model):
 
     for epoch in range(opt.start_epoch, opt.num_epochs + opt.start_epoch):
 
-        loss_epoch = [0 for i in range(opt.model_splits)]
-        loss_updates = [1 for i in range(opt.model_splits)]
+        loss_epoch = [0 for _ in range(opt.model_splits)]
+        loss_updates = [1 for _ in range(opt.model_splits)]
 
         for step, (img, label) in enumerate(train_loader):
 
@@ -70,42 +70,30 @@ def train(opt, model):
             label = label.to(opt.device)
 
             loss, _, _, accuracy = model(model_input, label, n=cur_train_module)
-            loss = torch.mean(loss, 0) # take mean over outputs of different GPUs
+            loss = torch.mean(loss, 0)  # Take mean over outputs of different GPUs.
             accuracy = torch.mean(accuracy, 0)
 
             if cur_train_module != opt.model_splits and opt.model_splits > 1:
                 loss = loss[cur_train_module].unsqueeze(0)
 
-            # loop through the losses of the modules and do gradient descent
             model.zero_grad()
+            overall_loss = sum(loss)
+            overall_loss.backward()
+            optimizer.step()
 
             for idx, cur_losses in enumerate(loss):
-                if len(loss) == 1 and opt.model_splits != 1:
-                    idx = cur_train_module
-                    
-                if idx == len(loss) - 1:
-                    cur_losses.backward()
-                else:
-                    cur_losses.backward(retain_graph=True)
-                    
-            for idx, cur_losses in enumerate(loss):
-                if len(loss) == 1 and opt.model_splits != 1:
-                    idx = cur_train_module
-                    
-                optimizer[idx].step()
-
                 print_loss = cur_losses.item()
                 print_acc = accuracy[idx].item()
+                loss_epoch[idx] += print_loss
+                loss_updates[idx] += 1
+
                 if step % print_idx == 0:
                     print("\t \t Loss: \t \t {:.4f}".format(print_loss))
                     if opt.loss == 1:
                         print("\t \t Accuracy: \t \t {:.4f}".format(print_acc))
 
-                loss_epoch[idx] += print_loss
-                loss_updates[idx] += 1
-
         if opt.validate:
-            validation_loss = validate(opt, model, test_loader) #test_loader corresponds to validation set here
+            validation_loss = validate(opt, model, test_loader)  # Test_loader corresponds to validation set here.
             logs.append_val_loss(validation_loss)
 
         logs.append_train_loss([x / loss_updates[idx] for idx, x in enumerate(loss_epoch)])

--- a/GreedyInfoMax/vision/models/load_vision_model.py
+++ b/GreedyInfoMax/vision/models/load_vision_model.py
@@ -10,17 +10,10 @@ def load_model_and_optimizer(opt, num_GPU=None, reload_model=False, calc_loss=Tr
         opt, calc_loss
     )
 
-    optimizer = []
-    if opt.model_splits == 1:
-        optimizer.append(
-            torch.optim.Adam(model.parameters(), lr=opt.learning_rate)
-        )
-    elif opt.model_splits >= 3:
-        # use separate optimizer for each module, so gradients don't get mixed up
-        for idx, layer in enumerate(model.encoder):
-            optimizer.append(torch.optim.Adam(layer.parameters(), lr=opt.learning_rate))
+    if opt.train_module != opt.model_splits and opt.model_splits > 1:
+        optimizer = torch.optim.Adam(model.encoder[opt.train_module].parameters(), lr=opt.learning_rate)
     else:
-        raise NotImplementedError
+        optimizer = torch.optim.Adam(model.parameters(), lr=opt.learning_rate)
 
     model, num_GPU = model_utils.distribute_over_GPUs(opt, model, num_GPU=num_GPU)
 


### PR DESCRIPTION
Improve training speed for both the audio and vision experiments by accumulating the module-wise losses and by using a single optimizer for all modules. 

Calling .detach() on the features between modules is enough to ensure that no gradients leak in between them.